### PR TITLE
Fix requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(name='apistrap',
       zip_safe=False,
       setup_requires=['pytest-runner'],
       tests_require=['pytest', 'pytest-mock', 'pytest-flask'],
-      install_requires=['flasgger', 'flask', 'schematics'],
+      install_requires=['flasgger', 'flask', 'schematics', 'more_itertools'],
       )


### PR DESCRIPTION
@Teyras @FloopCZ we should decide a way of specifying reqs. These duplicite locations are not ok. 

Note: setup.py isn't even tested as CI installs by glone/install reqs