### PR TITLE
Implement operation ID autogeneration

### DIFF
--- a/apistrap/decorators.py
+++ b/apistrap/decorators.py
@@ -71,7 +71,17 @@ class AutodocDecorator:
 
                 wrapped_func.specs_dict["parameters"].append(param_data)
 
+        wrapped_func.specs_dict["operationId"] = self._snake_to_camel(wrapped_func.__name__)
+
         return wrapped_func
+
+    @staticmethod
+    def _snake_to_camel(value):
+        """
+        Convert a string from snake_case to camelCase
+        """
+        result = ''.join(x.capitalize() or '_' for x in value.split('_'))
+        return result[0].lower() + result[1:]
 
 
 class RespondsWithDecorator:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -35,13 +35,19 @@ def test_path_params_present_in_swagger_json(app_basic, client):
     path = "/view/{param}/{typed_param}"
 
     assert path in response.json["paths"].keys()
-    assert response.json["paths"][path]["get"] == {
-        "parameters": [{
+    assert response.json["paths"][path]["get"]["parameters"] == [
+        {
             "in": "path",
             "name": "param"
         }, {
             "in": "path",
             "name": "typed_param",
             "type": "integer"
-        }]
-    }
+        }
+    ]
+
+def test_operation_id_present_in_swagger_json(app_basic, client):
+    response = client.get("/swagger.json")
+    path = "/view/{param}/{typed_param}"
+    assert path in response.json["paths"].keys()
+    assert response.json["paths"][path]["get"]["operationId"] == "viewWithParams"


### PR DESCRIPTION
The operation ID is a unique identifier (this is currently not checked) of an operation that can be used by code generators for readable method names etc.